### PR TITLE
Add support for reading raw ultrasonic value

### DIFF
--- a/maqueen.ts
+++ b/maqueen.ts
@@ -22,6 +22,8 @@ const MOTER_ADDRESSS = 0x10
 enum PingUnit {
     //% block="cm"
     Centimeters,
+    //% block="raw"
+    Raw,
 }
 enum state {
         state1=0x10,
@@ -178,6 +180,7 @@ namespace maqueen {
         let x = d / 59;
         switch (unit) {
             case PingUnit.Centimeters: return Math.round(x);
+            case PingUnit.Raw: return Math.round(d);
             default: return Math.idiv(d, 2.54);
         }
     }


### PR DESCRIPTION
In certain situations it is useful to read the raw value from the ultrasonic sensor. Especially when we want to have maximum precision.

Therefore, we add an option to read the value raw, before we remove some of the information by dividing with 59 and rounding.

Hopefully, this can give students the possibility to navigate more precisely.